### PR TITLE
Added very basic help command and enabled Docker Compose.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # Use Python 3.10 base image
 FROM python:3.10
 
-# The enviroment variable ensures that the python output is set straight
-# to the terminal with out buffering it first
-ENV PYTHONUNBUFFERED 1
-
 # Mounts the application `app` to the image
 COPY . /app/
 WORKDIR /app
@@ -12,5 +8,6 @@ WORKDIR /app
 # Allows docker to cache installed dependencies between builds
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Run the bot.
-CMD [ "python", "main.py" ]
+# The enviroment variable ensures that the python output is set straight
+# to the terminal with out buffering it first
+ENV PYTHONUNBUFFERED 1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # discordbot
-This is the code for our Discord bot.
+The official Discord bot for The Art of Tech: Not Playing With A Full Tech
+
+## Building
+
+### Pip
+
+```bash
+# install dependencies
+$ pip install -r requirements.txt
+
+# run the bot
+$ python main.py
+```
+
+### Docker
+
+```bash
+# using Docker Compose to build our custom image
+$ docker-compose build
+
+# running it
+$ docker-compose up
+```

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -10,12 +10,50 @@ from disnake import Option, OptionType
 from disnake.ext import commands
 
 
+class HelpView(disnake.ui.View):
+    def __init__(self, *, timeout: float = 180) -> None:
+        super().__init__(timeout=timeout)
+
+        self.add_item(
+            disnake.ui.Button(
+                label='My Source Code',
+                style=disnake.ButtonStyle.link,
+                url='https://github.com/taotnpwaft/discordbot'
+            )
+        )
+        self.add_item(
+            disnake.ui.Button(
+                label='The Art of Tech | GitHub',
+                style=disnake.ButtonStyle.link,
+                url='https://github.com/taotnpwaft'
+            )
+        )
+
+
 class General(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
     async def cog_before_slash_command_invoke(self, inter: disnake.CommandInteraction) -> None:
-        await inter.response.defer(with_message=True)
+        await inter.response.defer()
+
+    @commands.slash_command(
+        name='help',
+        description='Get to know me!'
+    )
+    async def _help(self, inter: disnake.CommandInteraction) -> None:
+        embed = disnake.Embed(
+            title='Hi there! This is Tao!',
+            description="""
+            I hang around, wander and manage this server. I\'m a general-purpose Discord bot.
+            I can only do moderation stuff for now, but I think I'm growing up fast and I'll be
+            able to do much more pretty soon. You can, for now, ask about me to the
+            moderators of the Discord server.
+            """
+        ).set_thumbnail(
+            url=self.bot.user.avatar
+        )
+        await inter.send(embed=embed, view=HelpView())
 
     @commands.slash_command(
         name='greet',
@@ -27,7 +65,8 @@ class General(commands.Cog):
                 OptionType.user,
                 required=True
             )
-        ]
+        ],
+        dm_permission=False
     )
     async def _greet(self, inter: disnake.CommandInteraction, member: disnake.Member):
         await inter.send(f'Greetings, {member.mention}!')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  bot:
+    build: .
+    command: bash -c "python main.py"
+    container_name: taotnpwaft
+    volumes:
+      - .:/app


### PR DESCRIPTION
### Things changed:

- [x] A new `/help` slash command can be accessed. This contains basic interactions for letting the user connect with the organization. These interactions include social links like GitHub and Twitter (not added yet).
- [x] The bot now supports multi-container operation using the [Docker Compose](https://docs.docker.com/compose/) platform. The root markdown (README.md) has also been updated to showcase this change.